### PR TITLE
fix: treat API routes as CommonJS modules

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- add `api/package.json` with `type: commonjs` so Vercel executes API routes correctly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897adb8f6788323b530aab6f729ad90